### PR TITLE
Bool Coercion and String Split SMTs

### DIFF
--- a/src/main/java/com/rentpath/kafka/connect/transforms/BoolCoercionTransform.java
+++ b/src/main/java/com/rentpath/kafka/connect/transforms/BoolCoercionTransform.java
@@ -1,0 +1,121 @@
+package com.rentpath.kafka.connect.transforms;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.transforms.Transformation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.regex.Pattern;
+
+public class BoolCoercionTransform<R extends ConnectRecord<R>> implements Transformation<R> {
+    private static final Logger log = LoggerFactory.getLogger(BoolCoercionTransform.class);
+    public static final Pattern PATTERN_TRUE = Pattern.compile("(?i)^true$");
+    public static final Pattern PATTERN_FALSE = Pattern.compile("(?i)^false");
+    public static final Pattern PATTERN_ONE = Pattern.compile("^1$");
+    public static final Pattern PATTERN_ZERO = Pattern.compile("^0$");
+    public static final Pattern PATTERN_YES = Pattern.compile("^yes$");
+    public static final Pattern PATTERN_NO = Pattern.compile("^yes$");
+
+    private BoolCoercionTransformConfig config;
+
+    @Override
+    public R apply(R record) {
+        if (null == record.valueSchema() || Schema.Type.STRUCT != record.valueSchema().type()) {
+            log.trace("record.valueSchema() is null or record.valueSchema() is not a struct.");
+            return record;
+        }
+
+        Struct inputRecord = (Struct) record.value();
+        Schema inputSchema = inputRecord.schema();
+
+        final SchemaBuilder builder = SchemaBuilder.struct();
+        if (inputSchema.name() != null && !inputSchema.name().equals("")) {
+            builder.name(inputSchema.name());
+        }
+        if (inputSchema.isOptional()) {
+            builder.optional();
+        }
+        for (Field field : inputSchema.fields()) {
+            final Schema fieldSchema;
+            if (this.config.fields.contains(field.name())) {
+                fieldSchema = (field.schema().isOptional() || !config.coercionFalsifyNull || !config.coercionFalsifyEmpty) ?
+                        Schema.OPTIONAL_BOOLEAN_SCHEMA :
+                        Schema.BOOLEAN_SCHEMA;
+            } else {
+                fieldSchema = field.schema();
+            }
+            builder.field(field.name(), fieldSchema);
+        }
+        Schema schema = builder.build();
+        Struct struct = new Struct(schema);
+        for (Field field : inputSchema.fields()) {
+            if (this.config.fields.contains(field.name())) {
+                if (inputRecord.get(field.name()) == null) {
+                    if (config.coercionFalsifyNull)
+                        struct.put(field.name(), false);
+                    else
+                        struct.put(field.name(), null);
+                } else if (field.schema().type() == Schema.Type.STRING) {
+                    String v = inputRecord.getString(field.name());
+                    if (v.equals(""))
+                        if (config.coercionFalsifyEmpty)
+                            struct.put(field.name(), false);
+                        else
+                            struct.put(field.name(), null);
+                    else if (PATTERN_FALSE.matcher(v).matches() ||
+                            PATTERN_ZERO.matcher(v).matches() ||
+                            PATTERN_NO.matcher(v).matches())
+                        struct.put(field.name(), false);
+                    else if (PATTERN_TRUE.matcher(v).matches() ||
+                            PATTERN_ONE.matcher(v).matches() ||
+                            PATTERN_YES.matcher(v).matches())
+                        struct.put(field.name(), true);
+                    else
+                        throw new DataException(String.format("Field has non-boolean-interpretable string value: %s", v));
+                } else if (field.schema().type() == Schema.Type.INT8 ||
+                        field.schema().type() == Schema.Type.INT16 ||
+                        field.schema().type() == Schema.Type.INT32 ||
+                        field.schema().type() == Schema.Type.INT64) {
+                    long longValue = inputRecord.getInt64(field.name());
+                    if (longValue == 0)
+                        struct.put(field.name(), false);
+                    else
+                        struct.put(field.name(), true);
+                } else if (field.schema().type() == Schema.Type.BOOLEAN)
+                    struct.put(field.name(), inputRecord.getBoolean(field.name()));
+            } else {
+                struct.put(field.name(), inputRecord.get(field.name()));
+            }
+        }
+        return record.newRecord(
+                record.topic(),
+                record.kafkaPartition(),
+                record.keySchema(),
+                record.key(),
+                struct.schema(),
+                struct,
+                record.timestamp()
+        );
+    }
+
+    @Override
+    public ConfigDef config() {
+        return BoolStringTransformConfig.config();
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public void configure(Map<String, ?> map) {
+        this.config = new BoolCoercionTransformConfig(map);
+    }
+}

--- a/src/main/java/com/rentpath/kafka/connect/transforms/BoolCoercionTransform.java
+++ b/src/main/java/com/rentpath/kafka/connect/transforms/BoolCoercionTransform.java
@@ -17,11 +17,11 @@ import java.util.regex.Pattern;
 public class BoolCoercionTransform<R extends ConnectRecord<R>> implements Transformation<R> {
     private static final Logger log = LoggerFactory.getLogger(BoolCoercionTransform.class);
     public static final Pattern PATTERN_TRUE = Pattern.compile("(?i)^true$");
-    public static final Pattern PATTERN_FALSE = Pattern.compile("(?i)^false");
+    public static final Pattern PATTERN_FALSE = Pattern.compile("(?i)^false$");
     public static final Pattern PATTERN_ONE = Pattern.compile("^1$");
     public static final Pattern PATTERN_ZERO = Pattern.compile("^0$");
-    public static final Pattern PATTERN_YES = Pattern.compile("^yes$");
-    public static final Pattern PATTERN_NO = Pattern.compile("^yes$");
+    public static final Pattern PATTERN_YES = Pattern.compile("(?i)^yes$");
+    public static final Pattern PATTERN_NO = Pattern.compile("(?i)^no$");
 
     private BoolCoercionTransformConfig config;
 

--- a/src/main/java/com/rentpath/kafka/connect/transforms/BoolCoercionTransformConfig.java
+++ b/src/main/java/com/rentpath/kafka/connect/transforms/BoolCoercionTransformConfig.java
@@ -14,7 +14,7 @@ public class BoolCoercionTransformConfig extends AbstractConfig {
     static final String COERCION_FALSIFY_NULL_DOC = "Will a null value be interpreted as logical false or null (default)?";
     static final boolean COERCION_FALSIFY_NULL_DEFAULT = false;
 
-    public static final String COERCION_FALSIFY_EMPTY_CONF = "coercion.falsify.null";
+    public static final String COERCION_FALSIFY_EMPTY_CONF = "coercion.falsify.empty";
     static final String COERCION_FALSIFY_EMPTY_DOC = "Will an empty string value be interpreted as logical false or null (default)?";
     static final boolean COERCION_FALSIFY_EMPTY_DEFAULT = false;
 

--- a/src/main/java/com/rentpath/kafka/connect/transforms/BoolCoercionTransformConfig.java
+++ b/src/main/java/com/rentpath/kafka/connect/transforms/BoolCoercionTransformConfig.java
@@ -1,0 +1,39 @@
+package com.rentpath.kafka.connect.transforms;
+
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigDef;
+
+import java.util.List;
+import java.util.Map;
+
+public class BoolCoercionTransformConfig extends AbstractConfig {
+    public static final String FIELDS_CONF = "fields";
+    static final String FIELDS_DOC = "The fields in the source record that contain booleans to coerce";
+
+    public static final String COERCION_FALSIFY_NULL_CONF = "coercion.falsify.null";
+    static final String COERCION_FALSIFY_NULL_DOC = "Will a null value be interpreted as logical false or null (default)?";
+    static final boolean COERCION_FALSIFY_NULL_DEFAULT = false;
+
+    public static final String COERCION_FALSIFY_EMPTY_CONF = "coercion.falsify.null";
+    static final String COERCION_FALSIFY_EMPTY_DOC = "Will an empty string value be interpreted as logical false or null (default)?";
+    static final boolean COERCION_FALSIFY_EMPTY_DEFAULT = false;
+
+    public List<String> fields;
+    public boolean coercionFalsifyNull = false;
+    public boolean coercionFalsifyEmpty = false;
+
+    public BoolCoercionTransformConfig(Map<String, ?> parsedConfig) {
+        super(config(), parsedConfig);
+        this.fields = getList(FIELDS_CONF);
+        this.coercionFalsifyNull = getBoolean(COERCION_FALSIFY_NULL_CONF);
+        this.coercionFalsifyEmpty = getBoolean(COERCION_FALSIFY_EMPTY_CONF);
+    }
+
+    static ConfigDef config() {
+        return new ConfigDef()
+                .define(FIELDS_CONF, ConfigDef.Type.LIST, null, ConfigDef.Importance.HIGH, FIELDS_DOC)
+                .define(COERCION_FALSIFY_NULL_CONF, ConfigDef.Type.BOOLEAN, COERCION_FALSIFY_NULL_DEFAULT, ConfigDef.Importance.HIGH, COERCION_FALSIFY_NULL_DOC)
+                .define(COERCION_FALSIFY_EMPTY_CONF, ConfigDef.Type.BOOLEAN, COERCION_FALSIFY_EMPTY_DEFAULT, ConfigDef.Importance.HIGH, COERCION_FALSIFY_EMPTY_DOC);
+    }
+}
+

--- a/src/main/java/com/rentpath/kafka/connect/transforms/StringSplitTransform.java
+++ b/src/main/java/com/rentpath/kafka/connect/transforms/StringSplitTransform.java
@@ -1,0 +1,101 @@
+package com.rentpath.kafka.connect.transforms;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.transforms.Transformation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+public class StringSplitTransform<R extends ConnectRecord<R>> implements Transformation<R> {
+    private static final Logger log = LoggerFactory.getLogger(StringSplitTransform.class);
+
+    private StringSplitTransformConfig config;
+
+    @Override
+    public R apply(R record) {
+        if (null == record.valueSchema() || Schema.Type.STRUCT != record.valueSchema().type()) {
+            log.trace("record.valueSchema() is null or record.valueSchema() is not a struct.");
+            return record;
+        }
+
+        Struct inputRecord = (Struct) record.value();
+        Schema inputSchema = inputRecord.schema();
+
+        final SchemaBuilder builder = SchemaBuilder.struct();
+        if (inputSchema.name() != null && !inputSchema.name().equals("")) {
+            builder.name(inputSchema.name());
+        }
+        if (inputSchema.isOptional()) {
+            builder.optional();
+        }
+        for (Field field : inputSchema.fields()) {
+            final Schema fieldSchema;
+            if (this.config.fields.contains(field.name())) {
+                SchemaBuilder listBuilder = SchemaBuilder.array(
+                        config.elementNullifyEmpty ? Schema.OPTIONAL_STRING_SCHEMA : Schema.STRING_SCHEMA
+                );
+                if (field.schema().isOptional())
+                    listBuilder.optional();
+                fieldSchema = listBuilder.build();
+            } else {
+                fieldSchema = field.schema();
+            }
+            builder.field(field.name(), fieldSchema);
+        }
+        Schema schema = builder.build();
+        Struct struct = new Struct(schema);
+        for (Field field : schema.fields()) {
+            if (this.config.fields.contains(field.name())) {
+                String v = inputRecord.getString(field.name());
+                List<String> list = null;
+                if ((v == null && config.listifyNull) || (v != null && v.equals("") && !config.nullifyEmpty))
+                    list = new ArrayList<>();
+                else if (v != null && !v.equals("")) {
+                    list = new ArrayList<>();
+                    String[] originalStrs = v.split(config.delimiter);
+                    for (String element : originalStrs)
+                        if (element.equals("") && config.elementNullifyEmpty)
+                            list.add(null);
+                        else
+                            list.add(element);
+                }
+                struct.put(field.name(), list);
+            } else {
+                struct.put(field.name(), inputRecord.get(field.name()));
+            }
+        }
+        return record.newRecord(
+                record.topic(),
+                record.kafkaPartition(),
+                record.keySchema(),
+                record.key(),
+                struct.schema(),
+                struct,
+                record.timestamp()
+        );
+    }
+
+    @Override
+    public ConfigDef config() {
+        return ListJoinTransformConfig.config();
+    }
+
+    @Override
+    public void close() {
+
+    }
+
+    @Override
+    public void configure(Map<String, ?> map) {
+        this.config = new StringSplitTransformConfig(map);
+    }
+}

--- a/src/main/java/com/rentpath/kafka/connect/transforms/StringSplitTransformConfig.java
+++ b/src/main/java/com/rentpath/kafka/connect/transforms/StringSplitTransformConfig.java
@@ -19,11 +19,11 @@ public class StringSplitTransformConfig extends AbstractConfig {
     static final String ELEMENT_NULLIFY_EMPTY_DOC = "Whether empty elements in the split list (e.g. the second value of \"1,,2\") ought to be interpreted as null. If false (default), will interpret as empty string";
     static final boolean ELEMENT_NULLIFY_EMPTY_DEFAULT = false;
 
-    public static final String NULLIFY_EMPTY_CONF = "element.nullify.empty";
+    public static final String NULLIFY_EMPTY_CONF = "nullify.empty";
     static final String NULLIFY_EMPTY_DOC = "Whether an empty string source value should be interpreted as null or an empty list (default)";
     static final boolean NULLIFY_EMPTY_DEFAULT = false;
 
-    public static final String LISTIFY_NULL_CONF = "element.nullify.empty";
+    public static final String LISTIFY_NULL_CONF = "listify.null";
     static final String LISTIFY_NULL_DOC = "Whether a null sourc value should be interpreted as an empty list or null (default)";
     static final boolean LISTIFY_NULL_DEFAULT = false;
 

--- a/src/main/java/com/rentpath/kafka/connect/transforms/StringSplitTransformConfig.java
+++ b/src/main/java/com/rentpath/kafka/connect/transforms/StringSplitTransformConfig.java
@@ -1,0 +1,53 @@
+package com.rentpath.kafka.connect.transforms;
+
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigDef;
+
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+public class StringSplitTransformConfig extends AbstractConfig {
+    public static final String FIELDS_CONF = "fields";
+    static final String FIELDS_DOC = "The fields in the source record containing strings to split";
+
+    public static final String DELIMITER_CONF = "delimiter";
+    static final String DELIMITER_DOC = "The regular expression pattern to be used to split the string into a list";
+    static final String DELIMITER_DEFAULT = ",";
+
+    public static final String ELEMENT_NULLIFY_EMPTY_CONF = "element.nullify.empty";
+    static final String ELEMENT_NULLIFY_EMPTY_DOC = "Whether empty elements in the split list (e.g. the second value of \"1,,2\") ought to be interpreted as null. If false (default), will interpret as empty string";
+    static final boolean ELEMENT_NULLIFY_EMPTY_DEFAULT = false;
+
+    public static final String NULLIFY_EMPTY_CONF = "element.nullify.empty";
+    static final String NULLIFY_EMPTY_DOC = "Whether an empty string source value should be interpreted as null or an empty list (default)";
+    static final boolean NULLIFY_EMPTY_DEFAULT = false;
+
+    public static final String LISTIFY_NULL_CONF = "element.nullify.empty";
+    static final String LISTIFY_NULL_DOC = "Whether a null sourc value should be interpreted as an empty list or null (default)";
+    static final boolean LISTIFY_NULL_DEFAULT = false;
+
+    public final List<String> fields;
+    public final String delimiter;
+    public final boolean elementNullifyEmpty;
+    public final boolean nullifyEmpty;
+    public final boolean listifyNull;
+
+    public StringSplitTransformConfig(Map<String, ?> parsedConfig) {
+        super(config(), parsedConfig);
+        this.fields = getList(FIELDS_CONF);
+        this.delimiter = getString(DELIMITER_CONF);
+        this.elementNullifyEmpty = getBoolean(ELEMENT_NULLIFY_EMPTY_CONF);
+        this.nullifyEmpty = getBoolean(NULLIFY_EMPTY_CONF);
+        this.listifyNull = getBoolean(LISTIFY_NULL_CONF);
+    }
+
+    static ConfigDef config() {
+        return new ConfigDef()
+                .define(FIELDS_CONF, ConfigDef.Type.LIST, null, ConfigDef.Importance.HIGH, FIELDS_DOC)
+                .define(DELIMITER_CONF, ConfigDef.Type.STRING, DELIMITER_DEFAULT, ConfigDef.Importance.HIGH, DELIMITER_DOC)
+                .define(ELEMENT_NULLIFY_EMPTY_CONF, ConfigDef.Type.BOOLEAN, ELEMENT_NULLIFY_EMPTY_DEFAULT, ConfigDef.Importance.HIGH, ELEMENT_NULLIFY_EMPTY_DOC)
+                .define(NULLIFY_EMPTY_CONF, ConfigDef.Type.BOOLEAN, NULLIFY_EMPTY_DEFAULT, ConfigDef.Importance.HIGH, NULLIFY_EMPTY_DOC)
+                .define(LISTIFY_NULL_CONF, ConfigDef.Type.BOOLEAN, LISTIFY_NULL_DEFAULT, ConfigDef.Importance.HIGH, LISTIFY_NULL_DOC);
+    }
+}


### PR DESCRIPTION
[Card](https://rentpath.atlassian.net/browse/SRV-1179)

This adds two new SMTs (Single Message Transforms) that are effectively the inversions of the original two.

`BoolCoercionTransform` attempts to interpret a non-boolean source value as a boolean, e.g.:
- String values "true", "yes", and "1" (case-insensitive) are interpreted as logical `true`
- String values "false", "no", and "0" (case-insensitive) are interpreted as logical `false`
- Integer value 0 is interpreted as logical `false`
- Any other integer value is interpreted as logical `true`
- Boolean values are unchanged
Additionally, this transform has an optional flag to interpret a null source value as logical `false`.

`StringSplitTransform` attempts to interpret a delimited-string source value as a list of strings, with options to interpret null and empty values appropriately (see config class `StringSplitTransformConfig` for details).