### PR TITLE
Add union resolver SMT

### DIFF
--- a/src/main/java/com/rentpath/kafka/connect/transforms/UnionResolverTransform.java
+++ b/src/main/java/com/rentpath/kafka/connect/transforms/UnionResolverTransform.java
@@ -68,11 +68,13 @@ public class UnionResolverTransform<R extends ConnectRecord<R>> implements Trans
                 Struct union = inputRecord.getStruct(field.name());
                 String selectedPriorityType = null;
                 Object priorityValue;
-                for (String priorityType : config.resolutionPriorities) {
-                    priorityValue = union.get(priorityType);
-                    if (priorityValue != null) {
-                        selectedPriorityType = priorityType;
-                        break;
+                if (union != null) {
+                    for (String priorityType : config.resolutionPriorities) {
+                        priorityValue = union.get(priorityType);
+                        if (priorityValue != null) {
+                            selectedPriorityType = priorityType;
+                            break;
+                        }
                     }
                 }
                 if (selectedPriorityType != null) {
@@ -89,20 +91,25 @@ public class UnionResolverTransform<R extends ConnectRecord<R>> implements Trans
         Struct struct = new Struct(schema);
         for (Field field : inputSchema.fields()) {
             if (this.config.fields.contains(field.name()) && field.schema().type() == Schema.Type.STRUCT) {
-                switch (schema.field(field.name()).schema().type()) {
-                    case INT32:
-                        struct.put(field.name(), inputRecord.getStruct(field.name()).getInt32("int"));
-                        break;
-                    case INT64:
-                        struct.put(field.name(), inputRecord.getStruct(field.name()).getInt64("long"));
-                        break;
-                    case FLOAT32:
-                        struct.put(field.name(), inputRecord.getStruct(field.name()).getFloat32("float"));
-                        break;
-                    case FLOAT64:
-                        struct.put(field.name(), inputRecord.getStruct(field.name()).getFloat64("double"));
-                        break;
+                Struct inputStruct = inputRecord.getStruct(field.name());
+                Object outValue = null;
+                if (inputStruct != null) {
+                    switch (schema.field(field.name()).schema().type()) {
+                        case INT32:
+                            outValue = inputStruct.getInt32("int");
+                            break;
+                        case INT64:
+                            outValue = inputStruct.getInt64("long");
+                            break;
+                        case FLOAT32:
+                            outValue = inputStruct.getFloat32("float");
+                            break;
+                        case FLOAT64:
+                            outValue = inputStruct.getFloat64("double");
+                            break;
+                    }
                 }
+                struct.put(field.name(), outValue);
             } else {
                 struct.put(field.name(), inputRecord.get(field.name()));
             }

--- a/src/main/java/com/rentpath/kafka/connect/transforms/UnionResolverTransform.java
+++ b/src/main/java/com/rentpath/kafka/connect/transforms/UnionResolverTransform.java
@@ -27,12 +27,16 @@ public class UnionResolverTransform<R extends ConnectRecord<R>> implements Trans
         switch (type) {
             case "int":
                 builder = SchemaBuilder.int32();
+                break;
             case "long":
                 builder = SchemaBuilder.int64();
+                break;
             case "float":
                 builder = SchemaBuilder.float32();
+                break;
             case "double":
                 builder = SchemaBuilder.float64();
+                break;
         }
         if (builder != null) {
             if (isOptional)

--- a/src/main/java/com/rentpath/kafka/connect/transforms/UnionResolverTransform.java
+++ b/src/main/java/com/rentpath/kafka/connect/transforms/UnionResolverTransform.java
@@ -1,6 +1,5 @@
 package com.rentpath.kafka.connect.transforms;
 
-import com.sun.codemodel.internal.JCase;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.connector.ConnectRecord;
 import org.apache.kafka.connect.data.Field;
@@ -11,8 +10,6 @@ import org.apache.kafka.connect.transforms.Transformation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 
 /*

--- a/src/main/java/com/rentpath/kafka/connect/transforms/UnionResolverTransform.java
+++ b/src/main/java/com/rentpath/kafka/connect/transforms/UnionResolverTransform.java
@@ -1,0 +1,138 @@
+package com.rentpath.kafka.connect.transforms;
+
+import com.sun.codemodel.internal.JCase;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.transforms.Transformation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/*
+ This transform is used to take the raw bytes from a message with ByteArray value and wrap it in a struct with the
+ original value represented as a single field in that struct (as configured by the `field` parameter), such that it
+ may be consumed by connectors that _require_ structs such as the JDBC Sink Connector.
+*/
+public class UnionResolverTransform<R extends ConnectRecord<R>> implements Transformation<R> {
+    private static final Logger log = LoggerFactory.getLogger(UnionResolverTransform.class);
+
+    private UnionResolverTransformConfig config;
+
+    private Schema resolveTypeSchema(String type, boolean isOptional) {
+        SchemaBuilder builder = null;
+        switch (type) {
+            case "int":
+                builder = SchemaBuilder.int32();
+            case "long":
+                builder = SchemaBuilder.int64();
+            case "float":
+                builder = SchemaBuilder.float32();
+            case "double":
+                builder = SchemaBuilder.float64();
+        }
+        if (builder != null) {
+            if (isOptional)
+                return builder.optional().build();
+            else
+                return builder.build();
+        }
+        return null;
+    }
+
+    @Override
+    public R apply(R record) {
+        if (record.value() == null)
+            return record;
+        if (null == record.valueSchema() || Schema.Type.STRUCT != record.valueSchema().type()) {
+            log.trace("record.valueSchema() is null or record.valueSchema() is not a struct.");
+            return record;
+        }
+
+        Struct inputRecord = (Struct) record.value();
+        Schema inputSchema = inputRecord.schema();
+
+        final SchemaBuilder builder = SchemaBuilder.struct();
+        if (inputSchema.name() != null && !inputSchema.name().equals("")) {
+            builder.name(inputSchema.name());
+        }
+        if (inputSchema.isOptional()) {
+            builder.optional();
+        }
+        for (Field field : inputSchema.fields()) {
+            final Schema fieldSchema;
+            if (this.config.fields.contains(field.name()) && field.schema().type() == Schema.Type.STRUCT) {
+                Struct union = inputRecord.getStruct(field.name());
+                String selectedPriorityType = null;
+                Object priorityValue;
+                for (String priorityType : config.typePriorities) {
+                    priorityValue = union.get(priorityType);
+                    if (priorityValue != null) {
+                        selectedPriorityType = priorityType;
+                        break;
+                    }
+                }
+                if (selectedPriorityType != null) {
+                    fieldSchema = resolveTypeSchema(selectedPriorityType, field.schema().isOptional());
+                } else {
+                    fieldSchema = resolveTypeSchema(config.typePriorities.get(0), field.schema().isOptional());
+                }
+            } else {
+                fieldSchema = field.schema();
+            }
+            builder.field(field.name(), fieldSchema);
+        }
+        Schema schema = builder.build();
+        Struct struct = new Struct(schema);
+        for (Field field : inputSchema.fields()) {
+            if (this.config.fields.contains(field.name()) && field.schema().type() == Schema.Type.STRUCT) {
+                switch (schema.field(field.name()).schema().type()) {
+                    case INT32:
+                        struct.put(field.name(), inputRecord.getStruct(field.name()).getInt32("int"));
+                        break;
+                    case INT64:
+                        struct.put(field.name(), inputRecord.getStruct(field.name()).getInt64("long"));
+                        break;
+                    case FLOAT32:
+                        struct.put(field.name(), inputRecord.getStruct(field.name()).getFloat32("float"));
+                        break;
+                    case FLOAT64:
+                        struct.put(field.name(), inputRecord.getStruct(field.name()).getFloat64("double"));
+                        break;
+                }
+            } else {
+                struct.put(field.name(), inputRecord.get(field.name()));
+            }
+        }
+        return record.newRecord(
+                record.topic(),
+                record.kafkaPartition(),
+                record.keySchema(),
+                record.key(),
+                struct.schema(),
+                struct,
+                record.timestamp()
+        );
+    }
+
+    @Override
+    public ConfigDef config() {
+        return UnionResolverTransformConfig.config();
+    }
+
+    @Override
+    public void close() {
+
+    }
+
+    @Override
+    public void configure(Map<String, ?> map) {
+        this.config = new UnionResolverTransformConfig(map);
+    }
+}

--- a/src/main/java/com/rentpath/kafka/connect/transforms/UnionResolverTransform.java
+++ b/src/main/java/com/rentpath/kafka/connect/transforms/UnionResolverTransform.java
@@ -68,7 +68,7 @@ public class UnionResolverTransform<R extends ConnectRecord<R>> implements Trans
                 Struct union = inputRecord.getStruct(field.name());
                 String selectedPriorityType = null;
                 Object priorityValue;
-                for (String priorityType : config.typePriorities) {
+                for (String priorityType : config.resolutionPriorities) {
                     priorityValue = union.get(priorityType);
                     if (priorityValue != null) {
                         selectedPriorityType = priorityType;
@@ -78,7 +78,7 @@ public class UnionResolverTransform<R extends ConnectRecord<R>> implements Trans
                 if (selectedPriorityType != null) {
                     fieldSchema = resolveTypeSchema(selectedPriorityType, field.schema().isOptional());
                 } else {
-                    fieldSchema = resolveTypeSchema(config.typePriorities.get(0), field.schema().isOptional());
+                    fieldSchema = resolveTypeSchema(config.resolutionPriorities.get(0), field.schema().isOptional());
                 }
             } else {
                 fieldSchema = field.schema();

--- a/src/main/java/com/rentpath/kafka/connect/transforms/UnionResolverTransformConfig.java
+++ b/src/main/java/com/rentpath/kafka/connect/transforms/UnionResolverTransformConfig.java
@@ -13,24 +13,24 @@ import java.util.Map;
 */
 public class UnionResolverTransformConfig extends AbstractConfig {
     // example: "content"
-    public static final String FIELDS_CONF = "field";
-    public static final String TYPE_PRIORITIES_CONF = "type.priorities";
+    public static final String FIELDS_CONF = "fields";
+    public static final String RESOLUTION_PRIORITIES = "resolution.priorities";
     static final String FIELDS_DOC = "Comma-delimited list of fields to apply the union resolution to";
-    static final String TYPE_PRIORITIES_DOC = "Comma-delimited list of types to use from the union in order of priority";
+    static final String RESOLUTION_PRIORITIES_DOC = "Comma-delimited list of types to use from the union in order of priority";
 
     public final List<String> fields;
-    public final List<String> typePriorities;
+    public final List<String> resolutionPriorities;
 
     public UnionResolverTransformConfig(Map<String, ?> parsedConfig) {
         super(config(), parsedConfig);
         this.fields = getList(FIELDS_CONF);
-        this.typePriorities = getList(TYPE_PRIORITIES_CONF);
+        this.resolutionPriorities = getList(RESOLUTION_PRIORITIES);
     }
 
     static ConfigDef config() {
         return new ConfigDef()
                 .define(FIELDS_CONF, ConfigDef.Type.LIST, null, ConfigDef.Importance.HIGH, FIELDS_DOC)
-                .define(TYPE_PRIORITIES_CONF, ConfigDef.Type.LIST, null, ConfigDef.Importance.HIGH, TYPE_PRIORITIES_DOC);
+                .define(RESOLUTION_PRIORITIES, ConfigDef.Type.LIST, null, ConfigDef.Importance.HIGH, RESOLUTION_PRIORITIES_DOC);
     }
 }
 

--- a/src/main/java/com/rentpath/kafka/connect/transforms/UnionResolverTransformConfig.java
+++ b/src/main/java/com/rentpath/kafka/connect/transforms/UnionResolverTransformConfig.java
@@ -1,0 +1,36 @@
+package com.rentpath.kafka.connect.transforms;
+
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigDef;
+
+import java.util.List;
+import java.util.Map;
+
+/*
+ This transform is used to take the raw bytes from a message with ByteArray value and wrap it in a struct with the
+ original value represented as a single field in that struct (as configured by the `field` parameter), such that it
+ may be consumed by connectors that _require_ structs such as the JDBC Sink Connector.
+*/
+public class UnionResolverTransformConfig extends AbstractConfig {
+    // example: "content"
+    public static final String FIELDS_CONF = "field";
+    public static final String TYPE_PRIORITIES_CONF = "type.priorities";
+    static final String FIELDS_DOC = "Comma-delimited list of fields to apply the union resolution to";
+    static final String TYPE_PRIORITIES_DOC = "Comma-delimited list of types to use from the union in order of priority";
+
+    public final List<String> fields;
+    public final List<String> typePriorities;
+
+    public UnionResolverTransformConfig(Map<String, ?> parsedConfig) {
+        super(config(), parsedConfig);
+        this.fields = getList(FIELDS_CONF);
+        this.typePriorities = getList(TYPE_PRIORITIES_CONF);
+    }
+
+    static ConfigDef config() {
+        return new ConfigDef()
+                .define(FIELDS_CONF, ConfigDef.Type.LIST, null, ConfigDef.Importance.HIGH, FIELDS_DOC)
+                .define(TYPE_PRIORITIES_CONF, ConfigDef.Type.LIST, null, ConfigDef.Importance.HIGH, TYPE_PRIORITIES_DOC);
+    }
+}
+


### PR DESCRIPTION
[Card](https://rentpath.atlassian.net/browse/SRV-5038)

The Avro converter that handles translating an Avro schema to a connect schema is not intelligent enough to appropriately handle either-or unions, such as when a given field may be represented as multiple numeric types. This allows the specification of a transform that will select one of the specified numeric types in order of priority as configured.